### PR TITLE
Horn-Schnuck rhs fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ IF(WIN32)
   find_package(Boost 1.46.0) # find_package for boost works a little dif for Windows
 ELSE()
   set(Boost_USE_STATIC_LIBS   ON)
-  find_package(Boost 1.46.0 COMPONENTS program_options system filesystem timer chrono)
+  find_package(Boost 1.46.0 COMPONENTS program_options filesystem timer chrono system)
 ENDIF()
 
 if (Boost_FOUND)


### PR DESCRIPTION
Added a missing term to the rhs of the Horn-Schunck formulation. Global problems now print the residual and step norms at each iteration.

Switched the order of two Boost libraries to avoid a compilation error.