### PR TITLE
checkerboard calibration fix

### DIFF
--- a/src/opencv/DICe_StereoCalib.cpp
+++ b/src/opencv/DICe_StereoCalib.cpp
@@ -866,7 +866,7 @@ StereoCalib(const int mode,
           timg = img;
         else
           resize(img, timg, Size(), scale, scale);
-        if(mode==1||2){
+        if(mode==1 || mode == 2){
           // binary image
           Mat bi_src(timg.size(), timg.type());
           // apply thresholding

--- a/tests/component/opencv/DICe_TestStereoCalib.cpp
+++ b/tests/component/opencv/DICe_TestStereoCalib.cpp
@@ -95,6 +95,7 @@ int main(int argc, char *argv[]) {
   int mode = 0; // checkerboard
   int threshold = 30;
   const float rms = StereoCalib(mode, image_list, 6, 9, square_size, threshold, true, false, "checkerboard_cal.txt");
+	*outStream << "Square target rms error: " << rms << std::endl;
 
   if(rms <0.0 || rms > 0.75){
     *outStream << "Error, rms error too high or negative: " << rms << std::endl;


### PR DESCRIPTION
fix in dicecore DICe_StereoCalib.cpp for checkerboard calibration (mode 0) to keep it from going through the dot routine (ln 869). Added output in DICe_TestStereoCalib to always display the return rms value (ln98).