### PR TITLE
Added params file option for exodus output

### DIFF
--- a/src/base/DICe.h
+++ b/src/base/DICe.h
@@ -309,6 +309,8 @@ const char* const num_image_integration_points = "num_image_integration_points";
 const char* const global_element_type = "global_element_type";
 /// String parameter name, only for global DIC
 const char* const use_fixed_point_iterations = "use_fixed_point_iterations";
+/// String parameter name, only for global DIC
+const char* const write_exodus_output = "write_exodus_output";
 
 
 /// enums:
@@ -1061,6 +1063,12 @@ const Correlation_Parameter use_fixed_point_iterations_param(use_fixed_point_ite
   "Used only for global, uses the fixed point iteration scheme for the global method."
 );
 /// Correlation parameter and properties
+const Correlation_Parameter write_exodus_output_param(write_exodus_output,
+  BOOL_PARAM,
+  true,
+  "Used when DICE_ENABLE_GLOBAL is true, writes an exodus output file."
+);
+/// Correlation parameter and properties
 const Correlation_Parameter global_element_type_param(global_element_type,
   STRING_PARAM,
   true,
@@ -1149,7 +1157,7 @@ const Correlation_Parameter filter_failed_cine_pixels_param(filter_failed_cine_p
 // TODO don't forget to update this when adding a new one
 /// The total number of valid correlation parameters
 /// Vector of valid parameter names
-const int_t num_valid_correlation_params = 85;
+const int_t num_valid_correlation_params = 86;
 /// Vector oIf valid parameter names
 const Correlation_Parameter valid_correlation_params[num_valid_correlation_params] = {
   correlation_routine_param,
@@ -1236,7 +1244,8 @@ const Correlation_Parameter valid_correlation_params[num_valid_correlation_param
   global_element_type_param,
   num_image_integration_points_param,
   use_fixed_point_iterations_param,
-  compute_laplacian_image_param
+  compute_laplacian_image_param,
+  write_exodus_output_param,
 };
 
 // TODO don't forget to update this when adding a new one

--- a/src/core/DICe_ParameterUtilities.cpp
+++ b/src/core/DICe_ParameterUtilities.cpp
@@ -338,6 +338,7 @@ DICE_LIB_DLL_EXPORT void tracking_default_params(Teuchos::ParameterList *  defau
   defaultParams->set(DICe::global_solver,CG_SOLVER);
   defaultParams->set(DICe::global_element_type,"TRI6");
   defaultParams->set(DICe::num_image_integration_points,20);
+  defaultParams->set(DICe::write_exodus_output,true);
 }
 
 DICE_LIB_DLL_EXPORT void dice_default_params(Teuchos::ParameterList *  defaultParams){
@@ -395,6 +396,7 @@ DICE_LIB_DLL_EXPORT void dice_default_params(Teuchos::ParameterList *  defaultPa
   defaultParams->set(DICe::global_element_type,"TRI6");
   defaultParams->set(DICe::global_solver,CG_SOLVER);
   defaultParams->set(DICe::num_image_integration_points,20);
+  defaultParams->set(DICe::write_exodus_output,true);
 }
 
 }// End DICe Namespace

--- a/src/core/DICe_Schema.cpp
+++ b/src/core/DICe_Schema.cpp
@@ -572,6 +572,8 @@ Schema::set_params(const Teuchos::RCP<Teuchos::ParameterList> & params){
   levenberg_marquardt_regularization_factor_ = diceParams->get<double>(DICe::levenberg_marquardt_regularization_factor);
   TEUCHOS_TEST_FOR_EXCEPTION(!diceParams->isParameter(DICe::output_beta),std::runtime_error,"");
   output_beta_ = diceParams->get<bool>(DICe::output_beta);
+  TEUCHOS_TEST_FOR_EXCEPTION(!diceParams->isParameter(DICe::write_exodus_output),std::runtime_error,"");
+  write_exodus_output_ = diceParams->get<bool>(DICe::write_exodus_output);
   TEUCHOS_TEST_FOR_EXCEPTION(!diceParams->isParameter(DICe::use_search_initialization_for_failed_steps),std::runtime_error,"");
   use_search_initialization_for_failed_steps_ = diceParams->get<bool>(DICe::use_search_initialization_for_failed_steps);
   TEUCHOS_TEST_FOR_EXCEPTION(!diceParams->isParameter(DICe::normalize_gamma_with_active_pixels),std::runtime_error,"");
@@ -2939,14 +2941,16 @@ Schema::write_output(const std::string & output_folder,
   int_t proc_size = comm_->get_size();
 
 #ifdef DICE_ENABLE_GLOBAL // global is enabled doesn't mean the analysis is global DIC it just means exodus is available as an output format
-  if(frame_id_==first_frame_id_+1){
-    std::string output_dir= "";
-    if(init_params_!=Teuchos::null)
-      output_dir = init_params_->get<std::string>(DICe::output_folder,"");
-    DICe::mesh::create_output_exodus_file(mesh_,output_dir);
-    DICe::mesh::create_exodus_output_variable_names(mesh_);
+  if (write_exodus_output_) {
+    if(frame_id_==first_frame_id_+1){
+      std::string output_dir= "";
+      if(init_params_!=Teuchos::null)
+        output_dir = init_params_->get<std::string>(DICe::output_folder,"");
+      DICe::mesh::create_output_exodus_file(mesh_,output_dir);
+      DICe::mesh::create_exodus_output_variable_names(mesh_);
+    }
+    DICe::mesh::exodus_output_dump(mesh_,frame_id_-first_frame_id_,frame_id_-first_frame_id_);
   }
-  DICe::mesh::exodus_output_dump(mesh_,frame_id_-first_frame_id_,frame_id_-first_frame_id_);
 #endif
 
   if(no_text_output) return;

--- a/src/core/DICe_Schema.h
+++ b/src/core/DICe_Schema.h
@@ -780,6 +780,11 @@ public:
     return output_beta_;
   }
 
+  /// Returns true if exodus output should be written
+  bool write_exodus_output()const{
+    return write_exodus_output_;
+  }
+
   /// Evolve subsets as more pixels become visible that were previously obstructed
   bool use_subset_evolution()const{
     return use_subset_evolution_;
@@ -1224,6 +1229,8 @@ private:
   double path_distance_threshold_;
   /// true if the beta parameter should be computed by the objective
   bool output_beta_;
+  /// true if exodus output should be written
+  bool write_exodus_output_;
   /// true if search initialization should be used for failed steps (otherwise the subset is skipped)
   bool use_search_initialization_for_failed_steps_;
 #ifdef DICE_ENABLE_GLOBAL


### PR DESCRIPTION
Addresses #108

- Can turn off exodus output when DICe
  has been configured with DICE_ENABLE_GLOBAL
  by setting write_exodus_output = false
  in the params.xml file. 

